### PR TITLE
Youtube clear cache handler

### DIFF
--- a/podtube.py
+++ b/podtube.py
@@ -47,6 +47,7 @@ def make_app(config: ConfigParser):
         (r'/youtube/video/(.*)', youtube.VideoHandler),
         (r'/youtube/audio/(.*)', youtube.AudioHandler),
         (r'/youtube/user/@(.*)', youtube.UserHandler, {'channel_handler_path': '/youtube/channel/'}),
+        (r'/youtube/cache/', youtube.ClearCacheHandler),
         (r'/rumble/user/(.*)', rumble.UserHandler),
         (r'/rumble/channel/(.*)', rumble.ChannelHandler),
         (r'/rumble/video/(.*)', rumble.VideoHandler),

--- a/youtube.py
+++ b/youtube.py
@@ -846,6 +846,8 @@ class ClearCacheHandler(web.RequestHandler):
         self.write('<link rel="shortcut icon" href="favicon.ico">')
         self.write('</head><body>')
 
+        self.write(f"<label>Clear cache</label>")
+        self.write("<br/><br/>")
         self.write("<form method='POST'>")
         self.write(f"<label for='{ClearCacheHandler.VIDEO_LINKS}'>Cached video links: </label>")
         self.write(f"<select id='{ClearCacheHandler.VIDEO_LINKS}' name='{ClearCacheHandler.VIDEO_LINKS}'>")
@@ -903,7 +905,7 @@ class ClearCacheHandler(web.RequestHandler):
             self.write(f"<option value='{f}'>{f} ({size})</option>")
         self.write("</select>")
         self.write("<br/><br/>")
-        self.write("<input type='submit'>")
+        self.write("<input type='submit' value='CLEAR SELECTED CACHE' />")
         self.write("</form>")
         self.write("<br/>")
         


### PR DESCRIPTION
Added a page for forced clearing of YouTube's cache.
It can be useful in cases when you are sure that something has changed (an edited video has been re-uploaded or the stram has ended, and now a regular video can be downloaded in its place) and you want to get it without waiting for several hours of automatic cache clearing.